### PR TITLE
Ensure PCA initialization has small variance

### DIFF
--- a/fastTSNE/nearest_neighbors.py
+++ b/fastTSNE/nearest_neighbors.py
@@ -44,8 +44,7 @@ class KNNIndex:
 
 class KDTree(KNNIndex):
     def build(self, data):
-        self.index = NearestNeighbors(
-            algorithm='kd_tree', metric=self.metric, n_jobs=self.n_jobs)
+        self.index = NearestNeighbors(algorithm='kd_tree', metric=self.metric, n_jobs=self.n_jobs)
         self.index.fit(data)
 
     def query_train(self, data, k):

--- a/fastTSNE/pynndescent/pynndescent_.py
+++ b/fastTSNE/pynndescent/pynndescent_.py
@@ -451,7 +451,11 @@ class NNDescent(object):
         self.n_trees = n_trees
         self.n_neighbors = n_neighbors
         self.metric = metric
-        self.metric_kwds = metric_kwds or dict()
+
+        if metric_kwds is None:
+            metric_kwds = dict()
+        self.metric_kwds = metric_kwds
+
         self.leaf_size = leaf_size
         self.prune_level = pruning_level
         self.max_candidates = max_candidates

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -352,5 +352,19 @@ class TestTSNECallbackParams(unittest.TestCase):
 class TSNEInitialization(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.x = np.random.randn(100, 4)
-        cls.x_test = np.random.randn(25, 4)
+        # It would be nice if the initial data were not nicely behaved to test
+        # for low variance
+        cls.x = np.random.normal(100, 50, (25, 4))
+
+    def test_low_variance(self):
+        """Low variance of the initial embedding is very important for the
+        convergence of tSNE."""
+        # Cycle through various initializations
+        initializations = ['random', 'pca']
+        allowed = 1e-3
+
+        for init in initializations:
+            tsne = TSNE(initialization=init, perplexity=2)
+            embedding = tsne.prepare_initial(self.x)
+            np.testing.assert_array_less(np.var(embedding, axis=0), allowed,
+                                         'using the `%s` initialization' % init)

--- a/tests/test_tsne.py
+++ b/tests/test_tsne.py
@@ -354,20 +354,3 @@ class TSNEInitialization(unittest.TestCase):
     def setUpClass(cls):
         cls.x = np.random.randn(100, 4)
         cls.x_test = np.random.randn(25, 4)
-
-    def test_unfitted_pca_model(self):
-        """Using PCA initialization in `transform` should fail when the initial
-        embedding was initialized with PCA."""
-        tsne = TSNE(initialization='random')
-        embedding = tsne.fit(self.x)
-        # Transforming using `pca` init on embedding that did not use
-        # `pca` init did not fail
-        with self.assertRaises(AssertionError):
-            embedding.transform(self.x_test, initialization='pca')
-
-    def test_fitted_pca_model(self):
-        """Using PCA initialization in `transform` should work when the initial
-        embedding was initialized with PCA."""
-        tsne = TSNE(initialization='pca')
-        embedding = tsne.fit(self.x)
-        embedding.transform(self.x_test, initialization='pca')


### PR DESCRIPTION
- As per #10, it is vital for tSNE optimization that the initialization has small variance. Without this scaling, PCA initialization can potentially lead to really bad results.

- Remove `pca` option when embedding new points into an existing embedding. This makes no sense because likely the points in the original space would have moved significantly and adding new points would be meaningless.