### PR TITLE
Fix callback crash if callback was a function

### DIFF
--- a/fastTSNE/tsne.py
+++ b/fastTSNE/tsne.py
@@ -615,7 +615,8 @@ def gradient_descent(embedding, P, dof, n_iter, negative_gradient_method,
     # Notify the callbacks that the optimization is about to start
     if isinstance(callbacks, Iterable):
         for callback in callbacks:
-            callback.optimzation_about_to_start()
+            # Only call function if present on object
+            getattr(callback, 'optimzation_about_to_start', lambda: ...)()
 
     for iteration in range(n_iter):
         should_call_callback = use_callbacks and (iteration + 1) % callbacks_every_iters == 0


### PR DESCRIPTION
In case a callback was provided that was a simple function, then we would crash because functions have no `optimzation_about_to_start` property.