### PR TITLE
Simplify KL divergence correction

### DIFF
--- a/fastTSNE/tsne.py
+++ b/fastTSNE/tsne.py
@@ -630,7 +630,7 @@ def gradient_descent(embedding, P, dof, n_iter, negative_gradient_method,
 
         # Correct the KL divergence w.r.t. the exaggeration if needed
         if should_eval_error and exaggeration != 1:
-            error = (error - np.sum(P) * np.log(exaggeration)) / exaggeration
+            error = error / exaggeration - np.log(exaggeration)
 
         if should_call_callback:
             # Continue only if all the callbacks say so


### PR DESCRIPTION
We can simplify the KL divergence correction for early exaggeration. See discussion in https://github.com/KlugerLab/FIt-SNE/issues/37.