### PR TITLE
Fix compilation flags on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import numpy as np
 import setuptools
@@ -7,20 +8,24 @@ from setuptools import setup, Extension
 USE_CYTHON = os.environ.get('USE_CYTHON', False)
 ext = 'pyx' if USE_CYTHON else 'c'
 
+IS_WINDOWS = 'win' in sys.platform
+openmp_opt = '/openmp' if IS_WINDOWS else '-fopenmp'
+optim_opt = '/O3' if IS_WINDOWS else '-O3'
+
 extensions = [
     Extension('fastTSNE.quad_tree', ['fastTSNE/quad_tree.%s' % ext],
-              extra_compile_args=['-fopenmp', '-O3'],
-              extra_link_args=['-fopenmp', '-O3'],
+              extra_compile_args=[openmp_opt, optim_opt],
+              extra_link_args=[openmp_opt, optim_opt],
               include_dirs=[np.get_include()],
               ),
     Extension('fastTSNE._tsne', ['fastTSNE/_tsne.%s' % ext],
-              extra_compile_args=['-fopenmp', '-O3'],
-              extra_link_args=['-fopenmp', '-O3'],
+              extra_compile_args=[openmp_opt, optim_opt],
+              extra_link_args=[openmp_opt, optim_opt],
               include_dirs=[np.get_include()],
               ),
     Extension('fastTSNE.kl_divergence', ['fastTSNE/kl_divergence.%s' % ext],
-              extra_compile_args=['-fopenmp', '-O3'],
-              extra_link_args=['-fopenmp', '-O3'],
+              extra_compile_args=[openmp_opt, optim_opt],
+              extra_link_args=[openmp_opt, optim_opt],
               include_dirs=[np.get_include()],
               ),
 ]


### PR DESCRIPTION
The module was not being properly compiled on Windows, the `openmp` and `O3` flags aren't' the same on Windows. This resulted in the library being slower on Windows than scikit-learn (see #8)!