### PR TITLE
Properly handle distance metrics

### DIFF
--- a/fastTSNE/affinity.py
+++ b/fastTSNE/affinity.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 from . import _tsne
-from .nearest_neighbors import KDTree, NNDescent, KNNIndex
+from .nearest_neighbors import BallTree, NNDescent, KNNIndex
 
 try:
     import networkx as nx
@@ -50,7 +50,7 @@ class NearestNeighborAffinities(Affinities):
         k_neighbors = min(self.n_samples - 1, int(3 * perplexity))
 
         # Support shortcuts for built-in nearest neighbor methods
-        methods = {'exact': KDTree, 'approx': NNDescent}
+        methods = {'exact': BallTree, 'approx': NNDescent}
         if isinstance(method, KNNIndex):
             knn_index = method
 

--- a/fastTSNE/affinity.py
+++ b/fastTSNE/affinity.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 from . import _tsne
-from .nearest_neighbors import BallTree, NNDescent, KNNIndex
+from .nearest_neighbors import BallTree, NNDescent, KNNIndex, VALID_METRICS
 
 try:
     import networkx as nx
@@ -43,7 +43,7 @@ class Affinities:
 class NearestNeighborAffinities(Affinities):
     """Compute affinities using the nearest neighbors defined by perplexity."""
     def __init__(self, data, perplexity=30, method='approx', metric='euclidean',
-                 symmetrize=True, n_jobs=1, random_state=None):
+                 metric_params=None, symmetrize=True, n_jobs=1, random_state=None):
         self.n_samples = data.shape[0]
 
         perplexity = self.check_perplexity(perplexity)
@@ -57,9 +57,13 @@ class NearestNeighborAffinities(Affinities):
         elif method not in methods:
             raise ValueError('Unrecognized nearest neighbor algorithm `%s`. '
                              'Please choose one of the supported methods or '
-                             'provide a valid `KNNIndex` instance.')
+                             'provide a valid `KNNIndex` instance.' % method)
         else:
-            knn_index = methods[method](metric=metric, n_jobs=n_jobs, random_state=random_state)
+            if metric not in VALID_METRICS:
+                raise ValueError('Unrecognized distance metric `%s`. Please '
+                                 'choose one of the supported methods.' % metric)
+            knn_index = methods[method](metric=metric, metric_params=metric_params,
+                                        n_jobs=n_jobs, random_state=random_state)
 
         knn_index.build(data)
         neighbors, distances = knn_index.query_train(data, k=k_neighbors)

--- a/fastTSNE/nearest_neighbors.py
+++ b/fastTSNE/nearest_neighbors.py
@@ -44,9 +44,9 @@ class KNNIndex:
         """Query the index with new points."""
 
 
-class KDTree(KNNIndex):
+class BallTree(KNNIndex):
     def build(self, data):
-        self.index = NearestNeighbors(algorithm='kd_tree', metric=self.metric, n_jobs=self.n_jobs)
+        self.index = NearestNeighbors(algorithm='ball_tree', metric=self.metric, n_jobs=self.n_jobs)
         self.index.fit(data)
 
     def query_train(self, data, k):

--- a/fastTSNE/nearest_neighbors.py
+++ b/fastTSNE/nearest_neighbors.py
@@ -1,6 +1,6 @@
 import sys
 
-from sklearn.neighbors import NearestNeighbors
+from sklearn import neighbors
 from sklearn.utils import check_random_state
 
 # In case we're running on a 32bit system, we have to properly handle numba's
@@ -10,6 +10,7 @@ uns1 = sys.platform.startswith('win32') and sys.version_info[:2] == (2, 7)
 uns2 = sys.maxsize <= 2 ** 32
 if uns1 or uns2:
     import numba
+
     __njit_copy = numba.njit
 
     # Ignore njit decorator and run raw Python function
@@ -19,18 +20,26 @@ if uns1 or uns2:
     numba.njit = __njit_wrapper
 
     from . import pynndescent
+
     pynndescent.pynndescent_.numba.njit = __njit_wrapper
     pynndescent.distances.numba.njit = __njit_wrapper
     pynndescent.rp_trees.numba.njit = __njit_wrapper
     pynndescent.utils.numba.njit = __njit_wrapper
 
-from .pynndescent import NNDescent as LibNNDescent
+from . import pynndescent
+
+# To keep things simple and consistent, we'll only support distances that are
+# included in both exact and approximation nearest neighbor search libraries
+__ball_tree_metrics = set(neighbors.BallTree.valid_metrics)
+__nndescent_metrics = set(pynndescent.distances.named_distances)
+VALID_METRICS = sorted(list(__ball_tree_metrics & __nndescent_metrics))
 
 
 class KNNIndex:
-    def __init__(self, metric, n_jobs=1, random_state=None):
+    def __init__(self, metric, metric_params=None, n_jobs=1, random_state=None):
         self.index = None
         self.metric = metric
+        self.metric_params = metric_params
         self.n_jobs = n_jobs
         self.random_state = random_state
 
@@ -46,7 +55,10 @@ class KNNIndex:
 
 class BallTree(KNNIndex):
     def build(self, data):
-        self.index = NearestNeighbors(algorithm='ball_tree', metric=self.metric, n_jobs=self.n_jobs)
+        self.index = neighbors.NearestNeighbors(
+            algorithm='ball_tree', metric=self.metric,
+            metric_params=self.metric_params, n_jobs=self.n_jobs,
+        )
         self.index.fit(data)
 
     def query_train(self, data, k):
@@ -59,12 +71,12 @@ class BallTree(KNNIndex):
 
 
 class NNDescent(KNNIndex):
-    # TODO: Make mapping from sklearn metrics to lib metrics
-
     def build(self, data):
         random_state = check_random_state(self.random_state)
-        self.index = LibNNDescent(data, metric=self.metric, n_neighbors=5,
-                                  random_state=random_state)
+        self.index = pynndescent.NNDescent(
+            data, metric=self.metric, metric_kwds=self.metric_params,
+            n_neighbors=5, random_state=random_state,
+        )
 
     def query_train(self, data, k):
         search_neighbors = min(data.shape[0] - 1, k + 1)

--- a/fastTSNE/tsne.py
+++ b/fastTSNE/tsne.py
@@ -524,6 +524,8 @@ class TSNE:
     metric: str
         The metric to be used to compute affinities between points in the
         original space.
+    metric_params: Optional[dict]
+        Additional keyword arguments for the metric function.
     initial_momentum: float
         t-SNE optimization uses momentum for faster convergence. This value
         controls the momentum used during the *early optimization* phase.
@@ -587,8 +589,8 @@ class TSNE:
                  n_iter=750, late_exaggeration_iter=0, late_exaggeration=1.2,
                  theta=0.5, n_interpolation_points=3, min_num_intervals=10,
                  ints_in_interval=1, initialization='pca', metric='euclidean',
-                 initial_momentum=0.5, final_momentum=0.8, n_jobs=1,
-                 neighbors='exact', negative_gradient_method='bh',
+                 metric_params=None, initial_momentum=0.5, final_momentum=0.8,
+                 n_jobs=1, neighbors='exact', negative_gradient_method='bh',
                  callbacks=None, callbacks_every_iters=50, random_state=None):
         self.n_components = n_components
         self.perplexity = perplexity
@@ -604,6 +606,7 @@ class TSNE:
         self.ints_in_interval = ints_in_interval
         self.initialization = initialization
         self.metric = metric
+        self.metric_params = metric_params
         self.initial_momentum = initial_momentum
         self.final_momentum = final_momentum
         self.n_jobs = n_jobs
@@ -693,7 +696,7 @@ class TSNE:
         # Compute the affinities for the input data
         affinities = NearestNeighborAffinities(
             X, self.perplexity, method=self.neighbors_method,
-            metric=self.metric, n_jobs=self.n_jobs,
+            metric=self.metric, metric_params=self.metric_params, n_jobs=self.n_jobs,
         )
 
         gradient_descent_params = {


### PR DESCRIPTION
##### Issue
Distance metrics had undefined behaviour i.e. it was up to the library to raise errors and handle everything.

##### Description of changes
- Use only distance metrics available in both nearest neighbour libraries and exclude the others. If it's not a valid distance metric, then an appropriate error is raised.

- Use ball tree instead of KD tree because it supports many more distance metrics.