### PR TITLE
Allow decreasing perpleixties in perplexity based affinities

### DIFF
--- a/tests/test_affinities.py
+++ b/tests/test_affinities.py
@@ -2,7 +2,48 @@ import unittest
 
 import numpy as np
 
-from fastTSNE.affinity import Multiscale
+from fastTSNE.affinity import Multiscale, PerplexityBasedNN
+
+
+class TestPerplexityBased(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.x = np.random.normal(100, 50, (91, 4))
+
+    def test_properly_reduces_large_perplexity(self):
+        aff = PerplexityBasedNN(self.x, perplexity=40)
+        self.assertEqual(aff.perplexity, 30)
+
+    def test_handles_reducing_perplexity_value(self):
+        perplexity = 20
+        k_neighbors = perplexity * 3
+        aff = PerplexityBasedNN(self.x, perplexity=perplexity)
+
+        self.assertEqual(aff.perplexity, perplexity)
+
+        # Check that the initial `P` matrix is allright
+        n_samples = self.x.shape[0]
+        original_P = aff.P.copy()
+        # Can't check for equality because the matrix is symmetrized therefore
+        # each point may have non-zero values in more than just the k neighbors
+        self.assertTrue(original_P.nnz >= n_samples * k_neighbors)
+
+        # Check that lowering the perplexity properly changes affinity matrix
+        perplexity = 10
+        k_neighbors = perplexity * 3
+
+        aff.set_perplexity(perplexity)
+        self.assertEqual(aff.perplexity, perplexity)
+        reduced_P = aff.P.copy()
+        self.assertTrue(reduced_P.nnz >= n_samples * k_neighbors)
+        self.assertTrue(reduced_P.nnz < original_P.nnz,
+                        'Lower perplexities should consider less neighbors, '
+                        'resulting in a sparser affinity matrix')
+
+        # Raising the perplexity above the initial value would need to recompute
+        # the nearest neighbors, so it should raise an error
+        with self.assertRaises(RuntimeError):
+            aff.set_perplexity(30)
 
 
 class TestMultiscale(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Following the art of using t-SNE, good results can be obtained by first running t-SNE at a high perplexity to capture global structure, then decreasing to account for more local structure.

##### Description of changes
Add `set_perplexity` method to `PerplexityBasedNN`. This allows lowering the perplexity without having to first recompute all the nearest neighbors. Proper bandwidths for the Gaussians still need to be recomputed in order to form a new affinity matrix.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
