### PR TITLE
Fix wrong normalization for affinities in fixed sigma affinities

### DIFF
--- a/fastTSNE/affinity.py
+++ b/fastTSNE/affinity.py
@@ -250,7 +250,7 @@ class FixedSigmaNN(Affinities):
             P = (P + P.T) / 2
 
         # Convert weights to probabilities
-        P /= np.sum(conditional_P)
+        P /= np.sum(P)
 
         self.sigma = sigma
         self.k = k


### PR DESCRIPTION
##### Issue
For some reason, the affinity matrix in for fixed sigmas wasn't normalized properly.


##### Description of changes
Properly normalize.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
